### PR TITLE
chore: cname docs.availproject.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Below is a curated list of GitHub repositories that are actively tracking the va
 
 ### Static-Site Generator
 
-The [Avail Developer Documentation](https://availproject.github.io/) is built using [Docusaurus](https://docusaurus.io/), making it easy to serve and host its static files.
+The [Avail Developer Documentation](https://docs.availproject.org/) is built using [Docusaurus](https://docusaurus.io/), making it easy to serve and host its static files.
 
 ### Deployments
 
@@ -189,7 +189,7 @@ Your contributions can significantly enrich the Docs in the following ways:
 
 Contributing to the Avail Documentation is simple. You'll need a GitHub account and a basic understanding of Markdown syntax to get started.
 
-1. **Locate the Page**: Visit the [Avail Documentation page](https://availproject.github.io/) you wish to edit.
+1. **Locate the Page**: Visit the [Avail Documentation page](https://docs.availproject.org/) you wish to edit.
 2. **Navigate to the Bottom**: Scroll to the bottom of the page.
 3. **Edit Link**: Click on the **Edit this page** link. This will redirect you to the corresponding Markdown file on GitHub.
 4. **Edit Mode**: Once on GitHub, click the pencil icon located in the upper-right corner to enter edit mode.

--- a/docs/about/accounts.md
+++ b/docs/about/accounts.md
@@ -8,7 +8,7 @@ keywords:
   - avail
   - explorer
   - accounts
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docs/about/explorer.md
+++ b/docs/about/explorer.md
@@ -8,7 +8,7 @@ keywords:
   - avail
   - explorer
   - accounts
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docs/about/faucet.md
+++ b/docs/about/faucet.md
@@ -10,7 +10,7 @@ keywords:
   - accounts
   - faucet
   - funding
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 
 You can use the Discord Faucet to get Avail (AVL) tokens on the Kate

--- a/docs/about/introduction.md
+++ b/docs/about/introduction.md
@@ -9,7 +9,7 @@ keywords:
   - availability
   - scale
   - rollup
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';

--- a/docs/about/introduction/appid.md
+++ b/docs/about/introduction/appid.md
@@ -9,7 +9,7 @@ keywords:
   - availability
   - scale
   - rollup
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 
 As a general purpose base layer, Avail is designed to support many

--- a/docs/about/introduction/light-clients.md
+++ b/docs/about/introduction/light-clients.md
@@ -9,7 +9,7 @@ keywords:
   - availability
   - scale
   - rollup
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 
 ## Light Clients

--- a/docs/about/introduction/validiums.md
+++ b/docs/about/introduction/validiums.md
@@ -9,7 +9,7 @@ keywords:
   - availability
   - scale
   - rollup
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 
 Due to the architecture of monolithic blockchains (such as Ethereum in

--- a/docs/api/light-client/light-client-embedding.md
+++ b/docs/api/light-client/light-client-embedding.md
@@ -12,7 +12,7 @@ keywords:
   - light client
   - embedding
   - rust
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/docs/api/light-client/using-light-client.md
+++ b/docs/api/light-client/using-light-client.md
@@ -12,7 +12,7 @@ keywords:
   - DHT
   - Kademlia
   - data sampling
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/docs/api/validiums.md
+++ b/docs/api/validiums.md
@@ -10,7 +10,7 @@ keywords:
 - scale
 - rollup
 - validium
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 
 ---
 

--- a/docs/build/app-chain.md
+++ b/docs/build/app-chain.md
@@ -11,6 +11,6 @@ keywords:
   - validium
   - modular
   - scalability
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';

--- a/docs/build/op-rollup.md
+++ b/docs/build/op-rollup.md
@@ -11,7 +11,7 @@ keywords:
   - validium
   - modular
   - scalability
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docs/build/quickstart.md
+++ b/docs/build/quickstart.md
@@ -10,7 +10,7 @@ keywords:
   - build
   - data availability
   - da
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docs/build/validium.md
+++ b/docs/build/validium.md
@@ -11,6 +11,6 @@ keywords:
   - validium
   - modular
   - scalability
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';

--- a/docs/build/volition.md
+++ b/docs/build/volition.md
@@ -11,6 +11,6 @@ keywords:
   - validium
   - modular
   - scalability
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';

--- a/docs/build/zk-rollup.md
+++ b/docs/build/zk-rollup.md
@@ -11,7 +11,7 @@ keywords:
   - validium
   - modular
   - scalability
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docs/operate/node-types.md
+++ b/docs/operate/node-types.md
@@ -10,7 +10,7 @@ keywords:
   - node
   - data availability
   - da
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docs/operate/node/0010-light-client.md
+++ b/docs/operate/node/0010-light-client.md
@@ -9,7 +9,7 @@ keywords:
   - node
   - data availability
   - da
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docs/operate/node/0020-full-node-binaries.md
+++ b/docs/operate/node/0020-full-node-binaries.md
@@ -10,7 +10,7 @@ keywords:
   - full node
   - data availability
   - da
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docs/operate/node/0030-full-node-docker.md
+++ b/docs/operate/node/0030-full-node-docker.md
@@ -11,7 +11,7 @@ keywords:
   - data availability
   - da
   - docker
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
@@ -29,7 +29,7 @@ We recommend downloading the pre-compiled binary for speed and convenience.
 First, you'll need to download the `kate-chainspec.raw.json` Chainspec configuration file.
 
 ```bash
-curl -L -o /mnt/avail/config/kate-chainspec.raw.json https://raw.githubusercontent.com/availproject/availproject.github.io/main/static/configs/kate/chainspec.raw.json
+curl -L -o /mnt/avail/config/kate-chainspec.raw.json https://raw.githubusercontent.com/availproject/docs.availproject.org/main/static/configs/kate/chainspec.raw.json
 ```
 
 ## Step 2: Launch Your Avail Node

--- a/docs/operate/node/0040-rpc-node.md
+++ b/docs/operate/node/0040-rpc-node.md
@@ -9,7 +9,7 @@ keywords:
   - node
   - data availability
   - da
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docs/operate/node/0050-bootstrap-node.md
+++ b/docs/operate/node/0050-bootstrap-node.md
@@ -9,7 +9,7 @@ keywords:
   - node
   - data availability
   - da
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docs/operate/node/0060-relay-node.md
+++ b/docs/operate/node/0060-relay-node.md
@@ -9,7 +9,7 @@ keywords:
   - node
   - data availability
   - da
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docs/operate/requirements.md
+++ b/docs/operate/requirements.md
@@ -10,7 +10,7 @@ keywords:
   - docker
   - validator
   - data availability
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/docs/operate/validator/0000-already-running-full-node.md
+++ b/docs/operate/validator/0000-already-running-full-node.md
@@ -8,7 +8,7 @@ keywords:
   - avail
   - node
   - validator
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docs/operate/validator/0010-validator-node-binaries.md
+++ b/docs/operate/validator/0010-validator-node-binaries.md
@@ -8,7 +8,7 @@ keywords:
   - avail
   - node
   - validator
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docs/operate/validator/0020-validator-node-docker.md
+++ b/docs/operate/validator/0020-validator-node-docker.md
@@ -10,7 +10,7 @@ keywords:
   - docker
   - validator
   - data availability
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
@@ -45,7 +45,7 @@ Download the Correct Chaispec file for the network in our case we are using the 
 In our case we will download the chainspec into our config folder as `kate-chainspec.raw.json`
 
 ```bash
-curl -L -o /mnt/avail/config/kate-chainspec.raw.json https://raw.githubusercontent.com/availproject/availproject.github.io/main/static/configs/kate/chainspec.raw.json
+curl -L -o /mnt/avail/config/kate-chainspec.raw.json https://raw.githubusercontent.com/availproject/docs.availproject.org/main/static/configs/kate/chainspec.raw.json
 ```
 
 Now that we've downloaded our Chainspec configuration, let's proceed to launch our Avail Node.

--- a/docs/operate/validator/0030-staking.md
+++ b/docs/operate/validator/0030-staking.md
@@ -8,7 +8,7 @@ keywords:
   - avail
   - node
   - validator
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docs/operate/validator/0040-backup-node.md
+++ b/docs/operate/validator/0040-backup-node.md
@@ -8,7 +8,7 @@ keywords:
   - avail
   - node
   - validator
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 
 ## Understanding Validator Directories

--- a/docs/operate/validator/0050-validator-monitoring.md
+++ b/docs/operate/validator/0050-validator-monitoring.md
@@ -9,7 +9,7 @@ keywords:
   - node
   - validator
   - monitoring
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
@@ -159,7 +159,7 @@ Set URL to http://localhost:9090, then test and save the connection
 Navigate back to your home page, on the top right in the menu select **Import dashboard**
  <img src={useBaseUrl("img/avail/validator-avail-grafana-add-dashboard.png")} width="100%" height="100%"/>
 
-Import the [Avail Node Metrics](https://github.com/availproject/availproject.github.io/blob/main/static/grafana/Avail-Node-Metrics.json) file
+Import the [Avail Node Metrics](https://github.com/availproject/docs.availproject.org/blob/main/static/grafana/Avail-Node-Metrics.json) file
  <img src={useBaseUrl("img/avail/validator-avail-grafana-add-dashboard-2.png")} width="100%" height="100%"/>
 
 You will have a new dashboard that opens and that you can use to monitor your node

--- a/docs/operate/validator/0060-validator-upgrade.md
+++ b/docs/operate/validator/0060-validator-upgrade.md
@@ -8,7 +8,7 @@ keywords:
   - avail
   - node
   - validator
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docs/operate/validator/0070-chilling.md
+++ b/docs/operate/validator/0070-chilling.md
@@ -8,7 +8,7 @@ keywords:
   - avail
   - node
   - validator
-image: https://availproject.github.io/img/avail/AvailDocs.png
+image: https://docs.availproject.org/img/avail/AvailDocs.png
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -334,7 +334,7 @@ module.exports = {
         docs: {
           routeBasePath: '/',
           sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: "https://github.com/availproject/docs.availproject.org/tree/main",
+          editUrl: "https://github.com/availproject/availproject.github.io/tree/main",
           path: "docs",
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,7 +5,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 module.exports = {
   title: "Avail Docs",
   tagline: "The official documentation hub for the Avail Project.",
-  url: "https://availproject.github.io/",
+  url: "https://docs.availproject.org/",
   baseUrl: "/",
   favicon: "/img/favicon.ico",
   organizationName: "availproject",
@@ -334,7 +334,7 @@ module.exports = {
         docs: {
           routeBasePath: '/',
           sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: "https://github.com/availproject/availproject.github.io/tree/main",
+          editUrl: "https://github.com/availproject/docs.availproject.org/tree/main",
           path: "docs",
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,

--- a/static/kate/chaininfo.txt
+++ b/static/kate/chaininfo.txt
@@ -1,4 +1,4 @@
-Raw Chainspec: https://availproject.github.io/assets/files/chainspec.raw-1905ee8ba4620c9cd6f1f378a84346eb.json
+Raw Chainspec: https://docs.availproject.org/assets/files/chainspec.raw-1905ee8ba4620c9cd6f1f378a84346eb.json
 
 Bootnodes:
 /dns/gateway-fullnode-001.kate.avail.tools/tcp/30333/p2p/12D3KooWB7mxRszUN9RJyQbttutEnEDtaUNMfr9SgvArPCfsDv2f


### PR DESCRIPTION
New domain for the documentation site - docs.availproject.org