### PR TITLE
Fixing a broken link

### DIFF
--- a/docs/about/introduction.md
+++ b/docs/about/introduction.md
@@ -232,7 +232,7 @@ The journey culminates with light clients performing proof verification. This pr
 
 ## What's Next?
 
-With your foundational understanding of Avail, if you're new to the ecosystem, be sure to visit the [<ins>Getting Started</ins>](/category/get-started/) section.
+With your foundational understanding of Avail, if you're new to the ecosystem, be sure to visit the [<ins>New user guide</ins>](/category/new-user-guide/) section.
 
 Additionally, consider experimenting with a light client. For this, the [<ins>Quickstart guide</ins>](/build/quickstart/) is great resource. To run an Avail light client, all you need to do is install and use the Avail CLI.
 


### PR DESCRIPTION
Pushing minor fix for broken link here brought to attention by Rishi:
https://docs-refresh-2-rjp2q.ondigitalocean.app/about/introduction/#whats-next

Chaing this:
![image](https://github.com/availproject/availproject.github.io/assets/56264430/7939835a-70a9-448a-bd27-a38717e4ca41)

to this:
![image](https://github.com/availproject/availproject.github.io/assets/56264430/ea1c42f4-8e31-443d-aa4c-cc1e8be9fcc3)
