### PR TITLE
Fixing a broken Link

### DIFF
--- a/docs/operate/validator/0060-validator-upgrade.md
+++ b/docs/operate/validator/0060-validator-upgrade.md
@@ -35,7 +35,7 @@ sudo systemctl stop availd.service
 ```
 cd /home/avail/avail-node/
 mv data-avail data-avail-backup
-wget https://github.com/availproject/avail/releases/download/v1.9.0.0/data-avail-linux-amd64.tar.gz
+wget https://github.com/availproject/avail/releases/download/v1.9.0.0/x86_64-generic-linux-data-avail.tar.gz
 tar -xvf data-avail-linux-amd64.tar.gz
 mv data-avail-linux-amd64 data-avail
 rm data-avail-linux-amd64.tar.gz


### PR DESCRIPTION
Fixing the broken link on the validator upgrade page. I Verified that the link indeed downloads the binary to my system.