### PR TITLE
Minor edits to /docs

### DIFF
--- a/docs/operate/node/0010-light-client.md
+++ b/docs/operate/node/0010-light-client.md
@@ -31,21 +31,19 @@ You can find the latest release binary in the `avail-light` repository.
 
 In this example, you will download the light client and connect to an existing public network.
 
-1. Download the latest Avail light client [<ins>release</ins>](https://github.com/availproject/avail-light/releases/). The light client is available pre-built for different architectures.
+1. Download the latest Avail light client [<ins>release</ins>](https://github.com/availproject/avail-light/releases/). The light client is available pre-built for different architectures. If you prefer building the light client yourself, see [<ins>build the Avail light client from source</ins>](#build-from-source).
 
-2. If you prefer building the light client yourself, see [<ins>build the Avail light client from source</ins>](#build-the-avail-light-client-from-source).
+2. Run the light client with the following pre-defined configuration file:
 
-3. Run the light client with the following pre-defined configuration file:
+   ```bash
+   ./avail-light --network goldberg
+   ```
 
-```bash
-./avail-light --network goldberg
-```
+   If you want to supply your own configuration file (see [<ins>reference</ins>](https://github.com/availproject/avail-light#configuration-reference)), use:
 
-4. If you want to supply your own [<ins>configuration file</ins>](https://github.com/availproject/avail-light#configuration-reference), use:
-
-```bash
-./avail-light --config config.yaml --network goldberg
-```
+   ```bash
+   ./avail-light --config config.yaml --network goldberg
+   ```
 
 That's it 🎉! You have successfully run the light client and connected to a public network. The light client should show output similar to the following:
 
@@ -98,7 +96,8 @@ If you want to connect the Avail light client to a local network, you will need 
    ./avail-light --network local
    ```
 
-4. If you want to supply your own [<ins>configuration file</ins>](https://github.com/availproject/avail-light#configuration-reference), use:
+   If you want to supply your own configuration file (see [<ins>reference</ins>](https://github.com/availproject/avail-light#configuration-reference)), use:
+
    ```bash
    ./avail-light --config config.yaml --network local
    ```


### PR DESCRIPTION
- Fixed a broken link
- Minor clean up of how the steps are structured in `How to Run an Avail Light Client` docs

**Before**
<img width="860" alt="image" src="https://github.com/availproject/availproject.github.io/assets/8350076/5a1b5103-67bb-4b91-9a49-5b545090ef48">

**After**
<img width="865" alt="image" src="https://github.com/availproject/availproject.github.io/assets/8350076/5f82e33e-5461-4e5f-a664-6eeb23ce1d71">
