### PR TITLE
chore: fix broken link

### DIFF
--- a/docs/about/introduction.md
+++ b/docs/about/introduction.md
@@ -232,7 +232,7 @@ The journey culminates with light clients performing proof verification. This pr
 
 ## What's Next?
 
-With your foundational understanding of Avail, if you're new to the ecosystem, be sure to visit the [<ins>New user guide</ins>](/category/new-user-guide/) section.
+With your foundational understanding of Avail, if you're new to the ecosystem, be sure to visit the [<ins>New user guide</ins>](/category/end-user-guide/) section.
 
 Additionally, consider experimenting with a light client. For this, the [<ins>Quickstart guide</ins>](/build/quickstart/) is great resource. To run an Avail light client, all you need to do is install and use the Avail CLI.
 


### PR DESCRIPTION
<img width="610" alt="image" src="https://github.com/availproject/availproject.github.io/assets/8350076/29030053-b967-49b0-90f6-b17b2b4614b3">

Noticed that one of the mods/devs linked to the new page for the previously broken link