### PR TITLE
fix: update upstream config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ yarn start
    > Refer to [GitHub Docs: Configuring a remote for a fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/configuring-a-remote-for-a-fork).
 
    ```bash
-   git remote add upstream https://github.com/availproject/avail-docs
+   git remote add upstream https://github.com/availproject/availproject.github.io
    ```
 
 5. **Sync Your Fork**


### PR DESCRIPTION
The upstream config in contribution guide is using wrong repo (probably legacy name).