### PR TITLE
Regular maintainance

### DIFF
--- a/pages/docs/networks.mdx
+++ b/pages/docs/networks.mdx
@@ -41,16 +41,26 @@ The Turing testnet will be a long-running testnet, designed to imitate
 mainnet as closely as possible.
 </Callout>
 
+|                          | **Turing Testnet**                                                                       | **Goldberg Testnet**                                                                 |
+| ------------------------ | -----------------------------------------------------------------------------------------| ------------------------------------------------------------------------------------ | 
+| **Status**               | **Active**                                                                               | **Depracated**                                                                       | 
+| **AvailApps Explorer**   | [<ins>https://explorer.avail.so/</ins>](https://explorer.avail.so/)                      | [<ins>https://explorer.avail.so/</ins>](https://explorer.avail.so/)                  |
+| **Subscan Explorer**     | [<ins>https://avail-turing.subscan.io/</ins>](https://avail-turing.subscan.io/)          | [<ins>https://avail-goldberg.subscan.io/</ins>](https://avail-goldberg.subscan.io/)  |
+| **RPC Endpoint**         | [<ins>https://turing-rpc.avail.so/rpc</ins>](https://turing-rpc.avail.so/rpc)            | [<ins>https://goldberg.avail.tools/api</ins>](https://goldberg.avail.tools/api)      |
+| **WS Endpoint**          | [<ins>wss://turing-rpc.avail.so/ws</ins>](wss://turing-rpc.avail.so/ws)                  | [<ins>wss://goldberg.avail.tools/ws</ins>](wss://goldberg.avail.tools/ws)            |
+| **Chain Spec**           | [<ins>chainspec.raw.json</ins>](https://github.com/availproject/avail/blob/main/misc/genesis/testnet.turing.chain.spec.raw.json) | [<ins>chainspec.raw.json</ins>](https://github.com/availproject/avail/blob/main/misc/genesis/testnet.goldberg.chain.raw.json)         |
+| **Node Version**         | [<ins>v2.1.3</ins>](https://github.com/availproject/avail/releases/tag/v2.2.1.0-rc1)     | [<ins>v1.10.0.0</ins>](https://github.com/availproject/avail/releases/tag/v1.10.0.0) |
+| **Light Client Version** | [<ins>v1.8.1</ins>](https://github.com/availproject/avail-light/releases/tag/v1.8.1)     | [<ins>v1.7.6</ins>](https://github.com/availproject/avail-light/releases/tag/v1.7.6) |
 
-|                          | **Goldberg Testnet**                                                                 | **Turing Testnet**                                                                       |
-| ------------------------ | ------------------------------------------------------------------------------------ | -----------------------------------------------------------------------------------------| 
-| **Status**               | **Depracated**                                                                           | **Active**                                                                               | 
-| **Explorer**             | [<ins>https://explorer.avail.so/</ins>](https://explorer.avail.so/)                  | [<ins>https://explorer.avail.so/</ins>](https://explorer.avail.so/)                      |
-| **RPC Endpoint**         | [<ins>https://goldberg.avail.tools/api</ins>](https://goldberg.avail.tools/api)      | [<ins>https://turing-rpc.avail.so/rpc</ins>](https://turing-rpc.avail.so/rpc)                  |
-| **WS Endpoint**          | [<ins>wss://goldberg.avail.tools/ws</ins>](wss://goldberg.avail.tools/ws)            | [<ins>wss://turing-rpc.avail.so/ws</ins>](wss://turing-rpc.avail.so/ws)                        |
-| **Chain Spec**           | [<ins>chainspec.raw.json</ins>](https://github.com/availproject/avail/blob/main/misc/genesis/testnet.goldberg.chain.raw.json)         | [<ins>chainspec.raw.json</ins>](https://github.com/availproject/avail/blob/main/misc/genesis/testnet.turing.chain.spec.raw.json)             |
-| **Node Version**         | [<ins>v1.10.0.0</ins>](https://github.com/availproject/avail/releases/tag/v1.10.0.0) | [<ins>v2.1.2</ins>](https://github.com/availproject/avail/releases/tag/v2.2.0.0-rc1)   |
-| **Light Client Version** | [<ins>v1.7.6</ins>](https://github.com/availproject/avail-light/releases/tag/v1.7.6) | [<ins>v1.8.1</ins>](https://github.com/availproject/avail-light/releases/tag/v1.8.1)   |
+## Alternate RPC Endpoints
+
+We at Avail have teamed up with some external partners to provide alternate options for
+people to connect to Avail DA. We will keep this table updated as we onboard more partners.
+
+| **Partner**              | **RPC Endpoint**                                                                       | **WSS Endpoint**                                                                       |
+| ------------------------ | ---------------------------------------------------------------------------------------| --------------------------------------------------------------------------------------|
+| **Ankr**                 | [<ins>https://rpc.ankr.com/avail_turing_testnet</ins>](https://rpc.ankr.com/avail_turing_testnet) | [<ins>wss://turing-testnet.avail-rpc.com</ins>](wss://turing-testnet.avail-rpc.com)   |
+| **Bware**                | [<ins>https://avail-turing.public.blastapi.io</ins>](https://avail-turing.public.blastapi.io) | [<ins>wss://avail-turing.public.blastapi.io</ins>](wss://avail-turing.public.blastapi.io) |
 
 ## Pioneering Blockchain Modularity
 

--- a/pages/docs/operate-a-node/become-a-validator/0010-basics.mdx
+++ b/pages/docs/operate-a-node/become-a-validator/0010-basics.mdx
@@ -31,7 +31,7 @@ Before trying anything, make sure that you fully read the chapter first before d
 
 ## Installation & Setup
 
-Our first step is to obtain the prebuilt binary for Avail Node. [We offer a wide range of prebuilds](https://github.com/availproject/avail/releases/tag/v2.2.0.0-rc1), but in case you don't see your Linux flavor or architecture here, head to the FAQ chapter to learn how to build your own executable.
+Our first step is to obtain the prebuilt binary for Avail Node. [We offer a wide range of prebuilds](https://github.com/availproject/avail/releases/tag/v2.2.1.0-rc1), but in case you don't see your Linux flavor or architecture here, head to the FAQ chapter to learn how to build your own executable.
 
 Once you have found your OS (or picked the generic one), execute the given command to obtain the needed Avail Node binary.
 

--- a/pages/docs/operate-a-node/become-a-validator/0020-simple-deployment.mdx
+++ b/pages/docs/operate-a-node/become-a-validator/0020-simple-deployment.mdx
@@ -106,13 +106,13 @@ pwd
 <Callout type="warning" emoji="⚠️">
 NODE VERSION FOR TURING<br/>
 Please note that the Avail node underwent major breaking changes while making upgrades to transition towards Turing.
-The **MINIMUM** version for Turing is `2.1.2`.
+The **MINIMUM** version for Turing is `2.1.3`.
 </Callout>
 
 ```bash
-# Obtaning v2.2.0.0-rc1 for Ubuntu 22.04
+# Obtaning v2.2.1.0-rc1 for Ubuntu 22.04
 # wget is a command-line utility for downloading files from the internet.
-wget https://github.com/availproject/avail/releases/download/v2.2.0.0-rc1/x86_64-ubuntu-2204-avail-node.tar.gz
+wget https://github.com/availproject/avail/releases/download/v2.2.1.0-rc1/x86_64-ubuntu-2204-avail-node.tar.gz
 
 # tar is a command-line utility for working with tarballs, compressed or uncompressed archives containing one or more files or directories.
 # The -x option extracts files from an archive, and the -f option specifies the archive file. When used together as tar -xf, it removes the contents of the specified archive file.

--- a/pages/docs/operate-a-node/run-a-full-node/full-node.mdx
+++ b/pages/docs/operate-a-node/run-a-full-node/full-node.mdx
@@ -21,11 +21,11 @@ There are two main ways of running an Avail node:
 1. Go to the [Avail node GitHub releases page](https://github.com/availproject/avail/releases/).
 There you will see a lot of pre-built binaries for each version of the Avail node.
 
-2. Please download the binary suitable from your system, of the latest recommended version, which as of now is `v2.2.0.0-rc1`.
+2. Please download the binary suitable from your system, of the latest recommended version, which as of now is `v2.2.1.0-rc1`.
 You can do this using the GUI or by running the following command in your terminal:
 
 ```bash
-curl -L -O https://github.com/availproject/avail/releases/download/v2.2.0.0-rc1/<YOUR-SYSTEM-SPECIFIC-BINARY>.tar.gz
+curl -L -O https://github.com/availproject/avail/releases/download/v2.2.1.0-rc1/<YOUR-SYSTEM-SPECIFIC-BINARY>.tar.gz
 ```
 3. Extract the downloaded file by opening a terminal in the location of the downloaded file and using the following command:
 
@@ -257,7 +257,7 @@ To download and run an Avail node using Docker:
 1. Simply run the following command in your terminal:
 
 ```bash
-docker run --restart=on-failure -d -v /root/avail/node-data:/da/node-data -p 9944:9944 -p 30333:30333 docker.io/availj/avail:v2.2.0.0-rc1 --chain turing -d ./output --name a-random-name
+docker run --restart=on-failure -d -v /root/avail/node-data:/da/node-data -p 9944:9944 -p 30333:30333 docker.io/availj/avail:v2.2.1.0-rc1 --chain turing -d ./output --name a-random-name
 ```
 - -d runs the container in the background
 - -v  mounts a volume into the container


### PR DESCRIPTION
Changelogs:

1. Switched the networks table in the networks page to show Turing before Goldberg.
2. Added Suscan links for both Turing and Goldberg.
3. Upgraded Avail node version from 2.1.2 -> 2.1.3.
4. Added `Ankr` and `Bware` RPC endpoints to the networks page.