### PR TITLE
removed 'avail-deno' from docs

### DIFF
--- a/pages/api-reference/avail-lc-api.mdx
+++ b/pages/api-reference/avail-lc-api.mdx
@@ -34,7 +34,7 @@ of the Avail light client](/docs/operate-a-node/run-a-light-client/0010-light-cl
 
 ## Setting up the dev environment
 
-Set up your dev enviornment with `curl` and `Rust`:
+Set up your dev environment with `curl` and `Rust`:
 
 <Tabs items={['CURL', 'Rust']}>
 

--- a/pages/api-reference/avail-node-api.mdx
+++ b/pages/api-reference/avail-node-api.mdx
@@ -4,7 +4,7 @@ import { Callout } from 'nextra/components'
 # Avail node API reference
 
 <Callout type="info">
-BEFORE WE START
+**BEFORE WE START**<br/>
 1. The Avail node supports an extensive list of extrinsics and various other types of calls that you can
 [try out in our explorer](https://explorer.availproject.org/#/extrinsics).
 2. This API reference currently documents only the most widely used extrinsics, but will be iterated upon
@@ -54,6 +54,14 @@ npm i -g ts-node
 </Tabs.Tab>
 
 <Tabs.Tab>
+
+<Callout type="warning">
+**AVAIL-DENO HAS BEEN SUNSET**<br/>
+1. The `avail-deno` SDK has been sunset and will not be maintained or upgraded in the future.
+
+2. We recommend you switch to `avail-js`. The SDK will work with `deno` out of the box. \
+Just run `deno run --allow-net your-file-name.ts` to run your `avail-js` code with `deno`.
+</Callout>
 
 1. Make sure `avail-deno` is installed on your system. You can refer to [Deno's docs](https://docs.deno.com/runtime/manual/) for the same.
 

--- a/pages/api-reference/avail-node-api/balances-transfer-all.mdx
+++ b/pages/api-reference/avail-node-api/balances-transfer-all.mdx
@@ -46,7 +46,7 @@ hash is returned.
 ## Minimal Example
 
 <Callout type="info">
-1. You will need to set up the dev enviornment required to run this example. 
+1. You will need to set up the dev environment required to run this example. 
 For instructions, [check out our docs here](/api-reference/avail-node-api#setting-up-the-dev-environment).
 
 2. If you're sending an extrinsic (i.e conducting a transaction) you will need to replace the demo seed phrase with your own seed phrase.

--- a/pages/api-reference/avail-node-api/balances-transfer-allow-death.mdx
+++ b/pages/api-reference/avail-node-api/balances-transfer-allow-death.mdx
@@ -6,23 +6,13 @@ On-chain name of extrinsic: `balances_transferAllowDeath`
 
 ## Parameters
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 | parameter | type          | optional | description                                     |
 | --------- | ------------- | -------- | ----------------------------------------------- |
 | dest      | string        | false    | account that will receive funds                 |
 | value     | BN            | false    | amount that is send. 10^18 is equal to 1 AVL    |
-| waitFor   | WaitFor       | false    | wait for block inclusion or finalization        |
-| account   | KeyringPair   | false    | account that will send and sign the transaction |
-| options   | SignerOptions | true     | used to overwrite existing signer options       |
-</Tabs.Tab>
-
-<Tabs.Tab>
-| parameter | type          | optional | description                                     |
-| --------- | ------------- | -------- | ----------------------------------------------- |
-| dest      | string        | false    | account that will receive funds                 |
-| value     | BN            | false    | amount that is send. 10^18 is equal to 1 AVAIL    |
 | waitFor   | WaitFor       | false    | wait for block inclusion or finalization        |
 | account   | KeyringPair   | false    | account that will send and sign the transaction |
 | options   | SignerOptions | true     | used to overwrite existing signer options       |
@@ -57,14 +47,14 @@ hash is returned.
 ## Minimal Example
 
 <Callout type="info">
-1. You will need to set up the dev enviornment required to run this example. 
+1. You will need to set up the dev environment required to run this example. 
 For instructions, [check out our docs here](/api-reference/avail-node-api#setting-up-the-dev-environment).
 
 2. If you're sending an extrinsic (i.e conducting a transaction) you will need to replace the demo seed phrase with your own seed phrase.
 The rest of the code should work as is.
 </Callout>
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
+<Tabs items={['avail-js',  'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 
@@ -101,42 +91,6 @@ main()
 
 ```bash
 ts-node your-file-name.ts
-```
-</Tabs.Tab>
-
-<Tabs.Tab>
-
-1. Inside `your-file-name.ts`, add the following code:
-
-```typescript filename="avail-deno"
-import { BN, Keyring, SDK, WaitFor } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
-
-const Alice = "This is a random seed phrase please replace with your own";
- 
-const account = new Keyring({ type: "sr25519" }).addFromUri(Alice);
-const dest = "5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw"; // Eve
-const amount = new BN(10).pow(new BN(18)); // one Avail
-
-const result = await sdk.tx.balances.transferAllowDeath(dest, amount, WaitFor.BlockInclusion, account);
-if (result.isErr) {
-	console.log(result.reason);
-	Deno.exit(1);
-}
-
-console.log("From=" + result.event.from + ", To=" + result.event.to + ", Amount=" + result.event.amount);
-console.log("MaybeKilled=" + result.event2?.account);
-console.log("TxHash=" + result.txHash + ", BlockHash=" + result.blockHash);
-
-Deno.exit();
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
 ```
 </Tabs.Tab>
 

--- a/pages/api-reference/avail-node-api/balances-transfer-keep-alive.mdx
+++ b/pages/api-reference/avail-node-api/balances-transfer-keep-alive.mdx
@@ -6,23 +6,13 @@ On-chain name of extrinsic: `balances_transferKeepAlive`
 
 ## Parameters
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 | parameter | type          | optional | description                                     |
 | --------- | ------------- | -------- | ----------------------------------------------- |
 | dest      | string        | false    | account that will receive funds                 |
 | value     | BN            | false    | amount that is send. 10^18 is equal to 1 AVL    |
-| waitFor   | WaitFor       | false    | wait for block inclusion or finalization        |
-| account   | KeyringPair   | false    | account that will send and sign the transaction |
-| options   | SignerOptions | true     | used to overwrite existing signer options       |
-</Tabs.Tab>
-
-<Tabs.Tab>
-| parameter | type          | optional | description                                     |
-| --------- | ------------- | -------- | ----------------------------------------------- |
-| dest      | string        | false    | account that will receive funds                 |
-| value     | BN            | false    | amount that is send. 10^18 is equal to 1 AVAIL    |
 | waitFor   | WaitFor       | false    | wait for block inclusion or finalization        |
 | account   | KeyringPair   | false    | account that will send and sign the transaction |
 | options   | SignerOptions | true     | used to overwrite existing signer options       |
@@ -57,7 +47,7 @@ On failure, a reason of failure is returned. On Success, TransferEvent event, tr
 
 ## Basic Example
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 1. Inside `your-file-name.ts`, add the following code:
@@ -92,42 +82,6 @@ main()
 
 ```bash
 ts-node your-file-name.ts
-```
-</Tabs.Tab>
-
-
-<Tabs.Tab>
-
-1. Inside `your-file-name.ts`, add the following code:
-
-```typescript filename="avail-deno"
-import { BN, Keyring, SDK, WaitFor } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
-
-const Alice = "This is a random seed phrase please replace with your own";
- 
-const account = new Keyring({ type: "sr25519" }).addFromUri(Alice);
-const dest = "5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw"; // Eve
-const amount = new BN(12).mul(new BN(10).pow(new BN("18"))); // 12 AVAIL
-
-const result = await sdk.tx.balances.transferKeepAlive(dest, amount, WaitFor.BlockInclusion, account);
-if (result.isErr) {
-	console.log(result.reason);
-	Deno.exit(1);
-}
-
-console.log("From=" + result.event.from + ", To=" + result.event.to + ", Amount=" + result.event.amount);
-console.log("TxHash=" + result.txHash + ", BlockHash=" + result.blockHash);
-
-Deno.exit();
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
 ```
 </Tabs.Tab>
 

--- a/pages/api-reference/avail-node-api/da-app-keys.mdx
+++ b/pages/api-reference/avail-node-api/da-app-keys.mdx
@@ -11,16 +11,9 @@ On-chain name of method: `dataAvailability_appKeys`
 
 ## Parameters
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust']}>
+<Tabs items={['avail-js', 'avail-rust']}>
 
 <Tabs.Tab>
-| parameter | type          | optional | description                                           |
-| --------- | ------------- | -------- | ----------------------------------------------------- |
-|  key      | string        | true     | The `app_id` associated with this key will be fetched |
-</Tabs.Tab>
-
-<Tabs.Tab>
-
 | parameter | type          | optional | description                                           |
 | --------- | ------------- | -------- | ----------------------------------------------------- |
 |  key      | string        | true     | The `app_id` associated with this key will be fetched |
@@ -44,14 +37,14 @@ On failure, a reason for failure is returned. On sucess, the returned JSON objec
 ## Minimal example (Fetch a particular `app_id`)
 
 <Callout type="info">
-1. You will need to set up the dev enviornment required to run this example. 
+1. You will need to set up the dev environment required to run this example. 
 For instructions, [check out our docs here](/api-reference/avail-node-api#setting-up-the-dev-environment).
 
 2. If you're sending an extrinsic (i.e conducting a transaction) you will need to replace the demo seed phrase with your own seed phrase.
 The rest of the code should work as is.
 </Callout>
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust']}>
+<Tabs items={['avail-js', 'avail-rust']}>
 
 <Tabs.Tab>
 
@@ -79,38 +72,6 @@ main()
 ```bash
 ts-node your-file-name.ts
 ```
-</Tabs.Tab>
-
-<Tabs.Tab>
-
-1. Inside `your-file-name.ts`, add the following code:
-
-```typescript filename="avail-deno"
-import { SDK } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
-
-const key = "Reserved-2";
-const value = await sdk.api.query.dataAvailability.appKeys(key);
-console.log(value.toHuman());
-
-Deno.exit();
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
-```
-
-<br/>
-<details className="border p-3 rounded-md bg-[#EFF6FF] border-[#] hover:!bg-[#EFF6FF]">
-<summary>Sample Response:</summary>
-```json
-{ owner: "5CK87QdvhcSJvVa7ZACcEfd5i7J1GqoqbEFB2kzNn3Ms13fE", id: "2" }
-```
-</details>
 </Tabs.Tab>
 
 <Tabs.Tab>
@@ -224,7 +185,7 @@ as a mapping of their names to their owner and index.
 3. We are however including both scenarios here.
 </Callout>
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust']}>
+<Tabs items={['avail-js', 'avail-rust']}>
 
 <Tabs.Tab>
 
@@ -253,32 +214,6 @@ main()
 
 ```bash
 ts-node your-file-name.ts
-```
-</Tabs.Tab>
-
-<Tabs.Tab>
-
-1. Inside `your-file-name.ts`, add the following code:
-
-```typescript filename="avail-deno"
-import { SDK } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
-
-const appKeys = await sdk.api.query.dataAvailability.appKeys.entries();
-for (const [key, value] of appKeys) {
-	console.log(key.toHuman());
-	console.log(value.toHuman());
-}
-
-Deno.exit();   
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
 ```
 </Tabs.Tab>
 

--- a/pages/api-reference/avail-node-api/da-create-application-key.mdx
+++ b/pages/api-reference/avail-node-api/da-create-application-key.mdx
@@ -11,7 +11,7 @@ On-chain name of extrinsic: `dataAvailability_createApplicationKey`
 
 ## Parameters
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 | parameter | type          | optional | description                                     |
@@ -20,16 +20,6 @@ On-chain name of extrinsic: `dataAvailability_createApplicationKey`
 | waitFor   | WaitFor       | false    | wait for block inclusion or finalization        |
 | account   | KeyringPair   | false    | account that will send and sign the transaction |
 | options   | SignerOptions | true     | used to overwrite existing signer options       |
-</Tabs.Tab>
-
-<Tabs.Tab>
-| parameter | type          | optional | description                                     |
-| --------- | ------------- | -------- | ----------------------------------------------- |
-| key       | string        | false    | name of the application key                     |
-| waitFor   | WaitFor       | false    | wait for block inclusion or finalization        |
-| account   | KeyringPair   | false    | account that will send and sign the transaction |
-| options   | SignerOptions | true     | used to overwrite existing signer options       |
-
 </Tabs.Tab>
 
 <Tabs.Tab>
@@ -61,14 +51,14 @@ On failure, a reason of failure is returned. On Success, ApplicationKeyCreated e
 ## Minimal Example
 
 <Callout type="info">
-1. You will need to set up the dev enviornment required to run this example. 
+1. You will need to set up the dev environment required to run this example. 
 For instructions, [check out our docs here](/api-reference/avail-node-api#setting-up-the-dev-environment).
 
 2. If you're sending an extrinsic (i.e conducting a transaction) you will need to replace the demo seed phrase with your own seed phrase.
 The rest of the code should work as is.
 </Callout>
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 <Tabs.Tab>
 
 1. Inside `your-file-name.ts`, add the following code:
@@ -103,41 +93,6 @@ main()
 ```bash
 ts-node your-file-name.ts
 ```
-</Tabs.Tab>
-
-<Tabs.Tab>
-
-1. Inside `your-file-name.ts`, add the following code:
-
-```typescript filename="avail-deno"
-import { Keyring, SDK, WaitFor } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
-
-const Alice = "This is a random seed phrase please replace with your own";
- 
-const account = new Keyring({ type: "sr25519" }).addFromUri(Alice);
-const key = "MyAwesomeKey";
-
-const result = await sdk.tx.dataAvailability.createApplicationKey(key, WaitFor.BlockInclusion, account);
-if (result.isErr) {
-	console.log(result.reason);
-	Deno.exit(1);
-}
-
-console.log("Key=" + result.event.key + ", Owner=" + result.event.owner + ", Id=" + result.event.id);
-console.log("TxHash=" + result.txHash + ", BlockHash=" + result.blockHash);
-
-Deno.exit();
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
-```
-
 </Tabs.Tab>
 
 <Tabs.Tab>

--- a/pages/api-reference/avail-node-api/da-next-app-id.mdx
+++ b/pages/api-reference/avail-node-api/da-next-app-id.mdx
@@ -16,11 +16,7 @@ You can use this method to fetch the next available `app_id` for your awesome ro
 
 ## Parameters
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust']}>
-
-<Tabs.Tab>
-- None
-</Tabs.Tab>
+<Tabs items={['avail-js', 'avail-rust']}>
 
 <Tabs.Tab>
 - None
@@ -39,14 +35,14 @@ You can use this method to fetch the next available `app_id` for your awesome ro
 ## Minimal example (Fetch the next available `app_id`)
 
 <Callout type="info">
-1. You will need to set up the dev enviornment required to run this example. 
+1. You will need to set up the dev environment required to run this example. 
 For instructions, [check out our docs here](/api-reference/avail-node-api#setting-up-the-dev-environment).
 
 2. If you're sending an extrinsic (i.e conducting a transaction) you will need to replace the demo seed phrase with your own seed phrase.
 The rest of the code should work as is.
 </Callout>
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust']}>
+<Tabs items={['avail-js', 'avail-rust']}>
 
 <Tabs.Tab>
 
@@ -72,39 +68,6 @@ main()
 
 ```bash
 ts-node your-file-name.ts
-```
-
-<br/>
-<details className="border p-3 rounded-md bg-[#EFF6FF] border-[#] hover:!bg-[#EFF6FF]">
-<summary>Sample Response:</summary>
-```json
-99
-```
-</details>
-
-</Tabs.Tab>
-
-
-<Tabs.Tab>
-
-1. Inside `your-file-name.ts`, add the following code:
-
-```typescript filename="avail-deno"
-import { SDK } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
-
-const value = await sdk.api.query.dataAvailability.nextAppId();
-console.log(value.toHuman());
-
-Deno.exit();
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
 ```
 
 <br/>

--- a/pages/api-reference/avail-node-api/da-submit-data.mdx
+++ b/pages/api-reference/avail-node-api/da-submit-data.mdx
@@ -7,16 +7,7 @@ On-chain name of extrinsic: `dataAvailability_submitData`
 
 ## Parameters
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
-
-<Tabs.Tab>
-| parameter | type          | optional | description                                     |
-| --------- | ------------- | -------- | ----------------------------------------------- |
-| data      | string        | false    | data to be submitted                            |
-| waitFor   | WaitFor       | false    | wait for block inclusion or finalization        |
-| account   | KeyringPair   | false    | account that will send and sign the transaction |
-| options   | SignerOptions | true     | used to overwrite existing signer options       |
-</Tabs.Tab>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 | parameter | type          | optional | description                                     |
@@ -55,14 +46,14 @@ On failure, a reason of failure is returned. On Success, DataSubmitted event, tr
 ## Minimal example
 
 <Callout type="info">
-1. You will need to set up the dev enviornment required to run this example. 
+1. You will need to set up the dev environment required to run this example. 
 For instructions, [check out our docs here](/api-reference/avail-node-api#setting-up-the-dev-environment).
 
 2. If you're sending an extrinsic (i.e conducting a transaction) you will need to replace the demo seed phrase with your own seed phrase.
 The rest of the code should work as is.
 </Callout>
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 
@@ -102,57 +93,6 @@ ts-node your-file-name.ts
 </Tabs.Tab>
 
 <Tabs.Tab>
-
-1. Inside `your-file-name.ts`, paste the following code:
-
-```typescript filename="avail-deno"
-import { Keyring, SDK, WaitFor } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
-
-const Alice = "This is a random seed phrase please replace with your own";
-
-const account = new Keyring({ type: "sr25519" }).addFromUri(Alice);
-const data = "Sample data being submitted......";
-
-const result = await sdk.tx.dataAvailability.submitData(data, WaitFor.BlockInclusion, account);
-if (result.isErr) {
-	console.log(result.reason);
-	Deno.exit(1);
-}
-
-console.log("Data=" + result.txData.data);
-console.log("Who=" + result.event.who + ", DataHash=" + result.event.dataHash);
-console.log("TxHash=" + result.txHash + ", BlockHash=" + result.blockHash);
-
-Deno.exit();
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
-```
-<br/>
-
-<details className="border p-3 rounded-md bg-[#EFF6FF] border-[#] hover:!bg-[#EFF6FF]">
-<summary>Sample Response:</summary>
-
-```bash
-2024-08-20 23:11:26 PORTABLEREGISTRY: Unable to determine runtime Call type, cannot inspect sp_runtime::generic::unchecked_extrinsic::UncheckedExtrinsic
-2024-08-20 23:11:26        API/INIT: RPC methods not decorated: chainSpec_v1_chainName, chainSpec_v1_genesisHash, chainSpec_v1_properties
-2024-08-20 23:11:26        API/INIT: avail/37: Not decorating unknown runtime apis: 0x7915d720c2769ac8/2, 0x537dc9ebb965e7c0/4, 0x7f4c771cd72fb1da/1, KateApi/1, 0x28ac62e78c1baeac/1, 0xfbc577b9d747efd6/1
-Data=53616d706c652064617461206265696e67207375626d69747465642e2e2e2e2e2e
-Who=5CqgQkrDcdg5QrtuxT3H7WszrqgrBMhdwRbmMVXQzc4VSiEg, DataHash=0xdb10b83f02707eff828e95e4cb534871d6e1ca9fb10eb9ccc12795e9abf6f931
-TxHash=0x5ce5b90b30b640cc34a2301da591c4f1526726e5c732f5615166d24fd60313cc, BlockHash=0x86544212bfdf7578881acfafb148f2b6a154098568644c66a7a14ed3099bb342
-```
-</details>
-</Tabs.Tab>
-
-<Tabs.Tab>
-
-
 
 1. Inside `src/main.rs`, paste the following code:
 
@@ -286,7 +226,7 @@ attack vector since the rollups building on top of Avail DA can always filter ou
 3. If a specific `app_id` is not configured, the default is set to `0`.
 </Callout>
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 1. Inside `your-file-name.ts`, paste the following code:
@@ -323,42 +263,6 @@ main()
 
 ```bash
 ts-node your-file-name.ts
-```
-</Tabs.Tab>
-
-<Tabs.Tab>
-
-1. Inside `your-file-name.ts`, paste the following code:
-
-```typescript filename="avail-deno"
-import { Keyring, SDK, WaitFor } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-import { SignerOptions } from "https://deno.land/x/polkadot@0.2.45/api/submittable/types.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
- 
-const Alice = 'This is a random seed phrase please replace with your own';
- 
-const account = new Keyring({ type: "sr25519" }).addFromUri(Alice);
-const data = "Sample data being submitted......";
- 
-const result = await sdk.tx.dataAvailability.submitData(data, WaitFor.BlockInclusion, account,  {app_id: 89} as Partial<SignerOptions>);
-if (result.isErr) {
-	console.log(result.reason);
-	Deno.exit(1);
-}
- 
-console.log("Data=" + result.txData.data);
-console.log("Who=" + result.event.who + ", DataHash=" + result.event.dataHash);
-console.log("TxHash=" + result.txHash + ", BlockHash=" + result.blockHash);
- 
-Deno.exit();
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
 ```
 </Tabs.Tab>
 

--- a/pages/api-reference/avail-node-api/nomination-pools-create-with-pool-id.mdx
+++ b/pages/api-reference/avail-node-api/nomination-pools-create-with-pool-id.mdx
@@ -6,20 +6,7 @@ On-chain name of method: `nominationPools_createWithPoolId`
 
 ## Parameters
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust']}>
-
-<Tabs.Tab>
-| parameter | type          | optional | description                                        |
-| --------- | ------------- | -------- | -------------------------------------------------- |
-| amount    | BN            | false    | The amount of funds to delegate to the pool        |
-| root      | string        | false    | The account to set as [`PoolRoles::root`]          |
-| nominator | string        | false    | The account to set as the [`PoolRoles::nominator`] |
-| bouncer   | string        | false    | The account to set as the [`PoolRoles::bouncer`]   |
-| poolId    | number        | false    | pool id                                            |
-| waitFor   | WaitFor       | false    | wait for block inclusion or finalization           |
-| account   | KeyringPair   | false    | account that will send and sign the transaction    |
-| options   | SignerOptions | true     | used to overwrite existing signer options          |
-</Tabs.Tab>
+<Tabs items={['avail-js', 'avail-rust']}>
 
 <Tabs.Tab>
 | parameter | type          | optional | description                                        |
@@ -57,14 +44,14 @@ This object contains the details of the transaction and your newly created nomin
 ## Minimal example
 
 <Callout type="info">
-1. You will need to set up the dev enviornment required to run this example. 
+1. You will need to set up the dev environment required to run this example. 
 For instructions, [check out our docs here](/api-reference/avail-node-api#setting-up-the-dev-environment).
 
 2. If you're sending an extrinsic (i.e conducting a transaction) you will need to replace the demo seed phrase with your own seed phrase.
 The rest of the code should work as is.
 </Callout>
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust']}>
+<Tabs items={['avail-js', 'avail-rust']}>
 
 <Tabs.Tab>
 
@@ -137,68 +124,6 @@ ts-node your-file-name.ts
 ```
 </details>
 
-</Tabs.Tab>
-
-<Tabs.Tab>
-
-1. Inside `your-file-name.ts`, add the following code:
-
-```typescript filename="avail-deno"
-import { BN, Keyring, SDK, WaitFor } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
-
-const Alice = 'This is a random seed phrase please replace with your own';
-const account = new Keyring({ type: "sr25519" }).addFromUri(Alice);
-const amount = new BN(10).pow(new BN(18)).mul(new BN(10000)); // 10_000 Avail
-
-const root: string = "5CqgQkrDcdg5QrtuxT3H7WszrqgrBMhdwRbmMVXQzc4VSiEg"; // Alice
-const nominator: string = "5CqgQkrDcdg5QrtuxT3H7WszrqgrBMhdwRbmMVXQzc4VSiEg"; // Alice
-const bouncer: string = "5CqgQkrDcdg5QrtuxT3H7WszrqgrBMhdwRbmMVXQzc4VSiEg"; // Alice
-const poolId = 0;
-
-const result = await sdk.tx.nomination_pools.createWithPoolId(amount, root, nominator, bouncer, poolId, WaitFor.BlockInclusion, account);
-if (result.isErr) {
-	console.log(result.reason);
-	Deno.exit(1);
-}
-
-console.log(JSON.stringify(result, null, 4));
-
-Deno.exit();
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
-```
-
-<br/>
-<details className="border p-3 rounded-md bg-[#EFF6FF] border-[#] hover:!bg-[#EFF6FF]">
-<summary>Sample Response:</summary>
-```js
-{
-    "isErr": false,
-    "event": {
-        "depositor": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
-        "poolId": "0"
-    },
-    "event2": {
-        "member": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
-        "poolId": "0",
-        "bonded": "10000",
-        "joined": "true"
-    },
-    "events": [...],
-    "txHash": "0x6b50caed7950e67934cabbf88a1f7dc2e7e995ac608402f91a4db19be0da5c41",
-    "txIndex": 1,
-    "blockHash": "0xc06df7dbb1e404f54499f942479ddcffc92665c021ea07c2798fc2f354f403d3",
-    "blockNumber": 6
-}
-```
-</details>
 </Tabs.Tab>
 
 <Tabs.Tab>

--- a/pages/api-reference/avail-node-api/nomination-pools-create.mdx
+++ b/pages/api-reference/avail-node-api/nomination-pools-create.mdx
@@ -6,19 +6,7 @@ On-chain name of method: `nominationPools_create`
 
 ## Parameters
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust']}>
-
-<Tabs.Tab>
-| parameter | type          | optional | description                                        |
-| --------- | ------------- | -------- | -------------------------------------------------- |
-| amount    | BN            | false    | The amount of funds to delegate to the pool        |
-| root      | string        | false    | The account to set as [`PoolRoles::root`]          |
-| nominator | string        | false    | The account to set as the [`PoolRoles::nominator`] |
-| bouncer   | string        | false    | The account to set as the [`PoolRoles::bouncer`]   |
-| waitFor   | WaitFor       | false    | wait for block inclusion or finalization           |
-| account   | KeyringPair   | false    | account that will send and sign the transaction    |
-| options   | SignerOptions | true     | used to overwrite existing signer options          |
-</Tabs.Tab>
+<Tabs items={['avail-js', 'avail-rust']}>
 
 <Tabs.Tab>
 | parameter | type          | optional | description                                        |
@@ -54,14 +42,14 @@ This object contains the details of the transaction and your newly created nomin
 ## Minimal example
 
 <Callout type="info">
-1. You will need to set up the dev enviornment required to run this example. 
+1. You will need to set up the dev environment required to run this example. 
 For instructions, [check out our docs here](/api-reference/avail-node-api#setting-up-the-dev-environment).
 
 2. If you're sending an extrinsic (i.e conducting a transaction) you will need to replace the demo seed phrase with your own seed phrase.
 The rest of the code should work as is.
 </Callout>
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust']}>
+<Tabs items={['avail-js', 'avail-rust']}>
 
 <Tabs.Tab>
 
@@ -131,72 +119,6 @@ ts-node your-file-name.ts
 ```
 </details>
 
-</Tabs.Tab>
-
-<Tabs.Tab>
-
-1. Inside `your-file-name.ts`, add the following code:
-
-```typescript filename="avail-deno"
-import { BN, Keyring, SDK, WaitFor } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
-
-const Alice = 'This is a random seed phrase please replace with your own';
-const account = new Keyring({ type: "sr25519" }).addFromUri(Alice);
-const amount = new BN(10).pow(new BN(18)).mul(new BN(10000)); // 10_000 Avail
-
-const root: string = "5CqgQkrDcdg5QrtuxT3H7WszrqgrBMhdwRbmMVXQzc4VSiEg"; // Alice
-const nominator: string = "5CqgQkrDcdg5QrtuxT3H7WszrqgrBMhdwRbmMVXQzc4VSiEg"; // Alice
-const bouncer: string = "5CqgQkrDcdg5QrtuxT3H7WszrqgrBMhdwRbmMVXQzc4VSiEg"; // Alice
-
-const result = await sdk.tx.nomination_pools.create(amount, root, nominator, bouncer, WaitFor.BlockInclusion, account);
-if (result.isErr) {
-	console.log(result.reason);
-	Deno.exit(1);
-}
-
-console.log(JSON.stringify(result, null, 4));
-
-Deno.exit();
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
-```
-
-<br/>
-<details className="border p-3 rounded-md bg-[#EFF6FF] border-[#] hover:!bg-[#EFF6FF]">
-<summary>Sample Response:</summary>
-```js
-{
-    "isErr": false,
-	"event": {
-        "depositor": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-        "poolId": "1"
-    },
-    "event2": {
-        "member": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-        "poolId": "1",
-        "bonded": "10000",
-        "joined": "true"
-    },
-    "event": {
-        "key": "0x4d79417765736f6d654b6579",
-        "owner": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-        "id": "10"
-    },
-    "events": [...],
-    "txHash": "0x5ae9edbd2a2da96eeffc14cf9050d711082890fa6bfb8749ad2c4947565f3bd2",
-    "txIndex": 1,
-    "blockHash": "0x152338c1b0696d12664cf3d4c159af3d54beca151ba1ea8b00989a66dc8050b0",
-    "blockNumber": 1
-}
-```
-</details>
 </Tabs.Tab>
 
 <Tabs.Tab>

--- a/pages/api-reference/avail-node-api/nomination-pools-join.mdx
+++ b/pages/api-reference/avail-node-api/nomination-pools-join.mdx
@@ -6,17 +6,7 @@ On-chain name of method: `nominationPools_join`
 
 ## Parameters
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust']}>
-
-<Tabs.Tab>
-| parameter | type          | optional | description                                     |
-| --------- | ------------- | -------- | ----------------------------------------------- |
-| amount    | BN            | false    | The amount of funds to delegate to the pool     |
-| poolId    | number        | false    | pool id                                         |
-| waitFor   | WaitFor       | false    | wait for block inclusion or finalization        |
-| account   | KeyringPair   | false    | account that will send and sign the transaction |
-| options   | SignerOptions | true     | used to overwrite existing signer options       |
-</Tabs.Tab>
+<Tabs items={['avail-js', 'avail-rust']}>
 
 <Tabs.Tab>
 | parameter | type          | optional | description                                     |
@@ -48,14 +38,14 @@ This object contains the details of the transaction and some information about t
 ## Minimal example
 
 <Callout type="info">
-1. You will need to set up the dev enviornment required to run this example. 
+1. You will need to set up the dev environment required to run this example. 
 For instructions, [check out our docs here](/api-reference/avail-node-api#setting-up-the-dev-environment).
 
 2. If you're sending an extrinsic (i.e conducting a transaction) you will need to replace the demo seed phrase with your own seed phrase.
 The rest of the code should work as is.
 </Callout>
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust']}>
+<Tabs items={['avail-js', 'avail-rust']}>
 
 <Tabs.Tab>
 
@@ -89,60 +79,6 @@ main()
 
 ```bash
 ts-node your-file-name.ts
-```
-
-<br/>
-<details className="border p-3 rounded-md bg-[#EFF6FF] border-[#] hover:!bg-[#EFF6FF]">
-<summary>Sample Response:</summary>
-```js
-{
-    "isErr": false,
-    "event": {
-        "member": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
-        "poolId": "1",
-        "bonded": "10000",
-        "joined": "true"
-    },
-    "events": [...],
-    "txHash": "0x06baecbb8680e90d025d1fd08044d0d251054a89e82dd460022bdf3796020050",
-    "txIndex": 1,
-    "blockHash": "0x82078130da46adacf5bdff86618ab6e1c443fda6d883d9fcf967a41a2e29d612",
-    "blockNumber": 19
-}
-```
-</details>
-</Tabs.Tab>
-
-<Tabs.Tab>
-
-1. Inside `your-file-name.ts`, add the following code:
-
-```typescript filename="avail-deno"
-import { BN, Keyring, SDK, WaitFor } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
-
-const Alice = 'This is a random seed phrase please replace with your own';
-const account = new Keyring({ type: "sr25519" }).addFromUri(Alice);
-const amount = new BN(10).pow(new BN(18)).mul(new BN(10000)); // 10_000 Avail
-const poolId = 1;
-
-const result = await sdk.tx.nomination_pools.join(amount, poolId, WaitFor.BlockInclusion, account);
-if (result.isErr) {
-	console.log(result.reason);
-	Deno.exit(1);
-}
-
-console.log(JSON.stringify(result, null, 4));
-
-Deno.exit();
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
 ```
 
 <br/>

--- a/pages/api-reference/avail-node-api/nomination-pools-nominate.mdx
+++ b/pages/api-reference/avail-node-api/nomination-pools-nominate.mdx
@@ -6,7 +6,7 @@ On-chain name of method: `nominationPools_nominate`
 
 ## Parameters
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust']}>
+<Tabs items={['avail-js', 'avail-rust']}>
 
 <Tabs.Tab>
 | parameter  | type          | optional | description                                     |
@@ -16,15 +16,6 @@ On-chain name of method: `nominationPools_nominate`
 | waitFor    | WaitFor       | false    | wait for block inclusion or finalization        |
 | account    | KeyringPair   | false    | account that will send and sign the transaction |
 | options    | SignerOptions | true     | used to overwrite existing signer options       |
-</Tabs.Tab>
-
-<Tabs.Tab>
-| parameter | type          | optional | description                                     |
-| --------- | ------------- | -------- | ----------------------------------------------- |
-| targets   | string[]      | false    | list of validator addresses to nominate                   |
-| waitFor   | WaitFor       | false    | wait for block inclusion or finalization        |
-| account   | KeyringPair   | false    | account that will send and sign the transaction |
-| options   | SignerOptions | true     | used to overwrite existing signer options       |
 </Tabs.Tab>
 
 <Tabs.Tab>
@@ -46,14 +37,14 @@ This object contains the details of the transaction and the nomination pool.
 ## Minimal example
 
 <Callout type="info">
-1. You will need to set up the dev enviornment required to run this example. 
+1. You will need to set up the dev environment required to run this example. 
 For instructions, [check out our docs here](/api-reference/avail-node-api#setting-up-the-dev-environment).
 
 2. If you're sending an extrinsic (i.e conducting a transaction) you will need to replace the demo seed phrase with your own seed phrase.
 The rest of the code should work as is.
 </Callout>
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust']}>
+<Tabs items={['avail-js', 'avail-rust']}>
 
 <Tabs.Tab>
 1. Inside `your-file-name.ts`, add the following code:
@@ -102,63 +93,6 @@ ts-node your-file-name.ts
     "txIndex": 1,
     "blockHash": "0x84ef5a0ada4af71358ee701a2500bce7f6688efb554c32ba1a30c459f64d5370",
     "blockNumber": 48
-}
-```
-</details>
-</Tabs.Tab>
-
-<Tabs.Tab>
-
-1. Inside `your-file-name.ts`, add the following code:
-
-```typescript filename="avail-deno"
-import { Keyring, SDK, WaitFor } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
- 
-const Alice = 'This is a random seed phrase please replace with your own';
- 
-const account = new Keyring({ type: "sr25519" }).addFromUri(Alice);
-const targets = [
-	"5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY", 
-	"5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
-];
-
-const result = await sdk.tx.staking.nominate(targets, WaitFor.BlockInclusion, account);
-if (result.isErr) {
-	console.log(result.reason);
-	Deno.exit(1);
-}
-
-console.log(JSON.stringify(result, null, 4));
-
-Deno.exit();
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
-```
-
-<br/>
-<details className="border p-3 rounded-md bg-[#EFF6FF] border-[#] hover:!bg-[#EFF6FF]">
-<summary>Sample Response:</summary>
-```js
-{
-    "isErr": false,
-    "txData": {
-        "targets": [
-            "5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY",
-            "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
-        ]
-    },
-    "events": [...],
-    "txHash": "0x2f81a34f59d36eb7ada96ec1070358043026d7bd7cfb6fa5a532cc474190880b",
-    "txIndex": 1,
-    "blockHash": "0x49a57953aa2b2ba508f1c6991515309a0fe89723a79f3831f9a9263ba8c7baa4",
-    "blockNumber": 4
 }
 ```
 </details>

--- a/pages/api-reference/avail-node-api/staking-active-era.mdx
+++ b/pages/api-reference/avail-node-api/staking-active-era.mdx
@@ -6,11 +6,7 @@ On-chain name of method: `staking_activeEra`
 
 ## Parameters
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust']}>
-
-<Tabs.Tab>
-- None
-</Tabs.Tab>
+<Tabs items={['avail-js', 'avail-rust']}>
 
 <Tabs.Tab>
 - None
@@ -30,14 +26,14 @@ On-chain name of method: `staking_activeEra`
 ## Minimal example (Fetch the active era)
 
 <Callout type="info">
-1. You will need to set up the dev enviornment required to run this example. 
+1. You will need to set up the dev environment required to run this example. 
 For instructions, [check out our docs here](/api-reference/avail-node-api#setting-up-the-dev-environment).
 
 2. If you're sending an extrinsic (i.e conducting a transaction) you will need to replace the demo seed phrase with your own seed phrase.
 The rest of the code should work as is.
 </Callout>
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust']}>
+<Tabs items={['avail-js', 'avail-rust']}>
 
 <Tabs.Tab>
 
@@ -65,40 +61,6 @@ main()
 ts-node your-file-name.ts
 ```
 
-</Tabs.Tab>
-
-<Tabs.Tab>
-
-1. Inside `your-file-name.ts`, add the following code:
-
-```typescript filename="avail-deno"
-import { SDK } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
-
-const value = await sdk.api.query.staking.activeEra();
-console.log(value.toHuman());
-
-Deno.exit();
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
-```
-
-<br/>
-<details className="border p-3 rounded-md bg-[#EFF6FF] border-[#] hover:!bg-[#EFF6FF]">
-<summary>Sample Response:</summary>
-```json
-{ 
-    index: "174", 
-    start: "1,726,523,440,000" 
-}
-```
-</details>
 </Tabs.Tab>
 
 <Tabs.Tab>

--- a/pages/api-reference/avail-node-api/staking-bond.mdx
+++ b/pages/api-reference/avail-node-api/staking-bond.mdx
@@ -6,23 +6,13 @@ On-chain name of extrinsic: `staking_bond`
 
 ## Parameters
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 | parameter | type                     | optional | description                                             |
 | --------- | ------------------------ | -------- | ------------------------------------------------------- |
 | value     | BN                       | false    | amount that is bond. 10^18 is equal to 1 AVL            |
 | payee     | StakingRewardDestination | false    | Can be: "Stakzed", "Stash", "None" or an account address |
-| waitFor   | WaitFor                  | false    | wait for block inclusion or finalization                |
-| account   | KeyringPair              | false    | account that will send and sign the transaction         |
-| options   | SignerOptions            | true     | used to overwrite existing signer options               |
-</Tabs.Tab>
-
-<Tabs.Tab>
-| parameter | type                     | optional | description                                             |
-| --------- | ------------------------ | -------- | ------------------------------------------------------- |
-| value     | BN                       | false    | amount that is bond. 10^18 is equal to 1 AVAIL            |
-| payee     | StakingRewardDestination | false    | Can be: "Staked", "Stash", "None" or an account address |
 | waitFor   | WaitFor                  | false    | wait for block inclusion or finalization                |
 | account   | KeyringPair              | false    | account that will send and sign the transaction         |
 | options   | SignerOptions            | true     | used to overwrite existing signer options               |
@@ -56,14 +46,14 @@ On failure, a reason of failure is returned. On Success, Bonded event, transacti
 ## Minimal example
 
 <Callout type="info">
-1. You will need to set up the dev enviornment required to run this example. 
+1. You will need to set up the dev environment required to run this example. 
 For instructions, [check out our docs here](/api-reference/avail-node-api#setting-up-the-dev-environment).
 
 2. If you're sending an extrinsic (i.e conducting a transaction) you will need to replace the demo seed phrase with your own seed phrase.
 The rest of the code should work as is.
 </Callout>
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 
@@ -99,41 +89,6 @@ main()
 
 ```bash
 ts-node your-file-name.ts
-```
-</Tabs.Tab>
-
-<Tabs.Tab>
-
-1. Inside `your-file-name.ts`, paste the following code:
-
-```typescript filename="avail-deno"
-import { BN, Keyring, SDK, WaitFor } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
-
-const Alice = "This is a random seed phrase please replace with your own";
- 
-const account = new Keyring({ type: "sr25519" }).addFromUri(Alice);
-const value = new BN(100_000).mul(new BN(10).pow(new BN("18"))); // 100 000 Avail
-const payee = "Staked";
-
-const result = await sdk.tx.staking.bond(value, payee, WaitFor.BlockInclusion, account);
-if (result.isErr) {
-	console.log(result.reason);
-	Deno.exit(1);
-}
-
-console.log("Stash=" + result.event.stash + ", Amount=" + result.event.amount);
-console.log("TxHash=" + result.txHash + ", BlockHash=" + result.blockHash);
-
-Deno.exit();
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
 ```
 </Tabs.Tab>
 

--- a/pages/api-reference/avail-node-api/staking-chill.mdx
+++ b/pages/api-reference/avail-node-api/staking-chill.mdx
@@ -6,15 +6,7 @@ On-chain name of extrinsic: `staking_chill`
 
 ## Parameters
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
-
-<Tabs.Tab>
-| parameter | type          | optional | description                                     |
-| --------- | ------------- | -------- | ----------------------------------------------- |
-| waitFor   | WaitFor       | false    | wait for block inclusion or finalization        |
-| account   | KeyringPair   | false    | account that will send and sign the transaction |
-| options   | SignerOptions | true     | used to overwrite existing signer options       |
-</Tabs.Tab>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 | parameter | type          | optional | description                                     |
@@ -48,14 +40,14 @@ On failure, a reason of failure is returned. On Success, Chilled event, transact
 ## Minimal example
 
 <Callout type="info">
-1. You will need to set up the dev enviornment required to run this example. 
+1. You will need to set up the dev environment required to run this example. 
 For instructions, [check out our docs here](/api-reference/avail-node-api#setting-up-the-dev-environment).
 
 2. If you're sending an extrinsic (i.e conducting a transaction) you will need to replace the demo seed phrase with your own seed phrase.
 The rest of the code should work as is.
 </Callout>
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 
@@ -89,39 +81,6 @@ main()
 
 ```bash
 ts-node your-file-name.ts
-```
-</Tabs.Tab>
-
-<Tabs.Tab>
-
-1. Inside `your-file-name.ts`, paste the following code:
-
-```typescript filename="avail-deno"
-import { Keyring, SDK, WaitFor } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
-
-const Alice = "This is a random seed phrase please replace with your own";
- 
-const account = new Keyring({ type: "sr25519" }).addFromUri("Alice//stash");
-
-const result = await sdk.tx.staking.chill(WaitFor.BlockInclusion, account);
-if (result.isErr) {
-	console.log(result.reason);
-	Deno.exit(1);
-}
-
-console.log("Stash=" + result.event.stash);
-console.log("TxHash=" + result.txHash + ", BlockHash=" + result.blockHash);
-
-Deno.exit();
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
 ```
 </Tabs.Tab>
 

--- a/pages/api-reference/avail-node-api/staking-nominate.mdx
+++ b/pages/api-reference/avail-node-api/staking-nominate.mdx
@@ -6,16 +6,7 @@ On-chain name of extrinsic: `staking_nominate`
 
 ## Parameters
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
-
-<Tabs.Tab>
-| parameter | type          | optional | description                                     |
-| --------- | ------------- | -------- | ----------------------------------------------- |
-| targets   | string[]      | false    | list of addresses to nominate                   |
-| waitFor   | WaitFor       | false    | wait for block inclusion or finalization        |
-| account   | KeyringPair   | false    | account that will send and sign the transaction |
-| options   | SignerOptions | true     | used to overwrite existing signer options       |
-</Tabs.Tab>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 | parameter | type          | optional | description                                     |
@@ -52,14 +43,14 @@ On failure, a reason of failure is returned. On Success, Nominate transaction da
 ## Minimal example
 
 <Callout type="info">
-1. You will need to set up the dev enviornment required to run this example. 
+1. You will need to set up the dev environment required to run this example. 
 For instructions, [check out our docs here](/api-reference/avail-node-api#setting-up-the-dev-environment).
 
 2. If you're sending an extrinsic (i.e conducting a transaction) you will need to replace the demo seed phrase with your own seed phrase.
 The rest of the code should work as is.
 </Callout>
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 
@@ -97,43 +88,6 @@ main()
 
 ```bash
 ts-node your-file-name.ts
-```
-</Tabs.Tab>
-
-<Tabs.Tab>
-
-1. Inside `your-file-name.ts`, paste the following code:
-
-```typescript filename="avail-deno"
-import { Keyring, SDK, WaitFor } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
-
-const Alice = "This is a random seed phrase please replace with your own";
- 
-const account = new Keyring({ type: "sr25519" }).addFromUri(Alice);
-const targets = [
-	"5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY", // Alice Stash
-	"5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty", // Bob
-];
-
-const result = await sdk.tx.staking.nominate(targets, WaitFor.BlockInclusion, account);
-if (result.isErr) {
-	console.log(result.reason);
-	Deno.exit(1);
-}
-
-console.log("TxDataTargets=" + result.txData.targets);
-console.log("TxHash=" + result.txHash + ", BlockHash=" + result.blockHash);
-
-Deno.exit();
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
 ```
 </Tabs.Tab>
 

--- a/pages/api-reference/avail-node-api/staking-unbond.mdx
+++ b/pages/api-reference/avail-node-api/staking-unbond.mdx
@@ -6,16 +6,7 @@ On-chain name of extrinsic: `staking_unbond`
 
 ## Parameters
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
-
-<Tabs.Tab>
-| parameter | type          | optional | description                                     |
-| --------- | ------------- | -------- | ----------------------------------------------- |
-| value     | BN            | false    | amount of tokens to unbond                      |
-| waitFor   | WaitFor       | false    | wait for block inclusion or finalization        |
-| account   | KeyringPair   | false    | account that will send and sign the transaction |
-| options   | SignerOptions | true     | used to overwrite existing signer options       |
-</Tabs.Tab>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 | parameter | type          | optional | description                                     |
@@ -53,14 +44,14 @@ On failure, a reason of failure is returned. On Success, Unbonded event, transac
 ## Minimal example
 
 <Callout type="info">
-1. You will need to set up the dev enviornment required to run this example. 
+1. You will need to set up the dev environment required to run this example. 
 For instructions, [check out our docs here](/api-reference/avail-node-api#setting-up-the-dev-environment).
 
 2. If you're sending an extrinsic (i.e conducting a transaction) you will need to replace the demo seed phrase with your own seed phrase.
 The rest of the code should work as is.
 </Callout>
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 
@@ -95,40 +86,6 @@ main()
 
 ```bash
 ts-node your-file-name.ts
-```
-</Tabs.Tab>
-
-<Tabs.Tab>
-
-1. Inside `your-file-name.ts`, paste the following code:
-
-```typescript filename="avail-deno"
-import { BN, Keyring, SDK, WaitFor } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
-
-const Alice = "This is a random seed phrase please replace with your own";
- 
-const account = new Keyring({ type: "sr25519" }).addFromUri(Alice);
-const value = new BN(10).pow(new BN(18)); // one Avail
-
-const result = await sdk.tx.staking.unbond(value, WaitFor.BlockInclusion, account);
-if (result.isErr) {
-	console.log(result.reason);
-	Deno.exit(1);
-}
-
-console.log("Stash=" + result.event.stash + ", Amount=" + result.event.amount);
-console.log("TxHash=" + result.txHash + ", BlockHash=" + result.blockHash);
-
-Deno.exit();
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
 ```
 </Tabs.Tab>
 

--- a/pages/api-reference/avail-node-api/staking-validate.mdx
+++ b/pages/api-reference/avail-node-api/staking-validate.mdx
@@ -6,17 +6,7 @@ On-chain name of extrinsic: `staking_validate`
 
 ## Parameters
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
-
-<Tabs.Tab>
-| parameter  | type          | optional | description                                           |
-| ---------- | ------------- | -------- | ----------------------------------------------------- |
-| commission | number        | false    | how much validator charge nominators in 0 - 100 range |
-| blocked    | boolean       | false    | whether or not this validator accepts nominations     |
-| waitFor    | WaitFor       | false    | wait for block inclusion or finalization              |
-| account    | KeyringPair   | false    | account that will send and sign the transaction       |
-| options    | SignerOptions | true     | used to overwrite existing signer options             |
-</Tabs.Tab>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 | parameter  | type          | optional | description                                           |
@@ -55,14 +45,14 @@ On failure, a reason of failure is returned. On Success, ValidatorPrefsSet event
 ## Minimal example
 
 <Callout type="info">
-1. You will need to set up the dev enviornment required to run this example. 
+1. You will need to set up the dev environment required to run this example. 
 For instructions, [check out our docs here](/api-reference/avail-node-api#setting-up-the-dev-environment).
 
 2. If you're sending an extrinsic (i.e conducting a transaction) you will need to replace the demo seed phrase with your own seed phrase.
 The rest of the code should work as is.
 </Callout>
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 
@@ -100,41 +90,6 @@ main()
 
 ```bash
 ts-node your-file-name.ts
-```
-</Tabs.Tab>
-
-<Tabs.Tab>
-
-1. Inside `your-file-name.ts`, paste the following code:
-
-```typescript filename="avail-deno"
-import { Keyring, SDK, WaitFor } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
-
-const Alice = "This is a random seed phrase please replace with your own";
- 
-const account = new Keyring({ type: "sr25519" }).addFromUri(Alice);
-const commission = 5; // 5%
-const blocked = false;
-
-const result = await sdk.tx.staking.validate(commission, blocked, WaitFor.BlockInclusion, account);
-if (result.isErr) {
-	console.log(result.reason);
-	Deno.exit(1);
-}
-
-console.log("Stash=" + result.event.stash + ", Commission=" + result.event.commission + ", Blocked=" + result.event.blocked);
-console.log("TxHash=" + result.txHash + ", BlockHash=" + result.blockHash);
-
-Deno.exit();
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
 ```
 </Tabs.Tab>
 

--- a/pages/api-reference/avail-node-api/system-account.mdx
+++ b/pages/api-reference/avail-node-api/system-account.mdx
@@ -6,30 +6,24 @@ On-chain name of method: `system_account`
 
 ## Parameters
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 | parameter | type          | optional | description                                           |
 | --------- | ------------- | -------- | ----------------------------------------------------- |
-|  addresss | SS58          | true     | The account  address to fetch information for         |
+|  address | SS58          | true     | The account  address to fetch information for         |
 </Tabs.Tab>
 
 <Tabs.Tab>
 | parameter | type          | optional | description                                           |
 | --------- | ------------- | -------- | ----------------------------------------------------- |
-|  addresss | SS58          | true     | The account  address to fetch information for         |
+|  address | SS58          | true     | The account  address to fetch information for         |
 </Tabs.Tab>
 
 <Tabs.Tab>
 | parameter | type          | optional | description                                           |
 | --------- | ------------- | -------- | ----------------------------------------------------- |
-|  addresss | SS58          | true     | The account  address to fetch information for         |
-</Tabs.Tab>
-
-<Tabs.Tab>
-| parameter | type          | optional | description                                           |
-| --------- | ------------- | -------- | ----------------------------------------------------- |
-|  addresss | SS58          | true     | The account  address to fetch information for         |
+|  address | SS58          | true     | The account  address to fetch information for         |
 </Tabs.Tab>
 
 </Tabs>
@@ -59,14 +53,14 @@ the number of transactions executed on Avail DA by that particular account.
 ## Minimal example (Fetch account information for a single account)
 
 <Callout type="info">
-1. You will need to set up the dev enviornment required to run this example. 
+1. You will need to set up the dev environment required to run this example. 
 For instructions, [check out our docs here](/api-reference/avail-node-api#setting-up-the-dev-environment).
 
 2. If you're sending an extrinsic (i.e conducting a transaction) you will need to replace the demo seed phrase with your own seed phrase.
 The rest of the code should work as is.
 </Callout>
 
-<Tabs items={['avail-js', 'avail-deno', 'avail-rust', 'avail-go']}>
+<Tabs items={['avail-js', 'avail-rust', 'avail-go']}>
 
 <Tabs.Tab>
 
@@ -94,49 +88,6 @@ main()
 ```bash
 ts-node your-file-name.ts
 ```
-</Tabs.Tab>
-
-<Tabs.Tab>
-
-1. Inside `your-file-name.ts`, add the following code:
-
-```typescript filename="avail-deno"
-import { SDK } from "https://raw.githubusercontent.com/availproject/avail/main/avail-deno/src/sdk.ts";
-
-const providerEndpoint = "wss://turing-rpc.avail.so/ws";
-const sdk = await SDK.New(providerEndpoint);
-
-const key = "5DDY2yzh8uCysYFAiRSTeQVwtZSKNF49CkQkyPH852xvrYKk";
-const value = await sdk.api.query.system.account(key);
-console.log(value.toHuman());
-
-Deno.exit();
-```
-
-2. Run the code using:
-
-```bash
-deno run --allow-net your-file-name.ts
-```
-
-<br/>
-<details className="border p-3 rounded-md bg-[#EFF6FF] border-[#] hover:!bg-[#EFF6FF]">
-<summary>Sample Response:</summary>
-```json
-{
-  nonce: "26",
-  consumers: "2",
-  providers: "1",
-  sufficients: "0",
-  data: {
-    free: "3,809,329,880,703,171,553,761",
-    reserved: "2,100,000,000,000,000,000",
-    frozen: "1,008,370,553,028,965,837,506",
-    flags: "170,141,183,460,469,231,731,687,303,715,884,105,728"
-  }
-}
-```
-</details>
 </Tabs.Tab>
 
 <Tabs.Tab>

--- a/public/reserveDocs/app-id-redacted-.mdx
+++ b/public/reserveDocs/app-id-redacted-.mdx
@@ -158,7 +158,7 @@ the operation will fail. This is why it makes sense to use the `appKeys` method 
 3. **Anyone can submit any sort of data to any `appID` regardless of whether or not they created it.** \
 *But what does this mean? And is this an attack vector?*
 
-- This is where it is important to understand that Avail DA is a DA layer, not an execution enviornment.
+- This is where it is important to understand that Avail DA is a DA layer, not an execution environment.
 We are not concerned with the validity of the data being submitted, only with its availability, which means we can support a wide variety of applications across multiple tech stacks.
 - This does not constitute an attack vector since that any app or execution layer building on top of Avail DA can always set up
 certain rules to filter out unwanted data submissions.

--- a/public/reserveDocs/quickstart.mdx
+++ b/public/reserveDocs/quickstart.mdx
@@ -63,11 +63,11 @@ They are available in three languages:
 - `Golang`: `avail-go`.
 
 <Callout type="info">
-**Setting up the dev enviornments**<br/>
-Please refer to [this page in our docs](/api-reference/avail-node-api#setting-up-the-dev-environment) to set up the respective dev enviornments for the SDKs.
+**Setting up the dev environments**<br/>
+Please refer to [this page in our docs](/api-reference/avail-node-api#setting-up-the-dev-environment) to set up the respective dev environments for the SDKs.
 </Callout>
 
-With your dev enviornment set up, we are ready to explore what the SDKs can offer.
+With your dev environment set up, we are ready to explore what the SDKs can offer.
 The next few snippets will focus on important lines within the code, but we have a full example at the end of the page.
 
 ### Create an API Instance


### PR DESCRIPTION
1. Removing `avail-deno` in favor of `avail-js`.
2. The disclaimer in the `avail-node dev env setup` should be enough for deno users to switch to `avail-js`, but can revisit.