### PR TITLE
Fix: Update Nexus SDK imports

### DIFF
--- a/app/nexus/avail-nexus-sdk/api-reference/page.mdx
+++ b/app/nexus/avail-nexus-sdk/api-reference/page.mdx
@@ -14,7 +14,7 @@ The Avail Nexus SDK provides a comprehensive set of APIs for cross-chain bridgin
 
 <Tabs.Tab>
 ```typescript showLineNumbers filename="Typescript"
-import { NexusSDK } from '@avail-project/nexus/core';
+import { NexusSDK } from '@avail-project/nexus';
 
 // Initialize SDK
 const sdk = new NexusSDK({ network: 'mainnet' });
@@ -71,7 +71,7 @@ import { NexusProvider,
   BridgeButton,
   TransferButton,
   BridgeAndExecuteButton
-} from '@avail-project/nexus/ui';
+} from '@avail-project/nexus-widgets';
 
 // 1. Wrap your app
 function App() {
@@ -149,7 +149,7 @@ function YourComponent() {
 <summary>How to fetch supported chains from the SDK?</summary>
 
 ```typescript showLineNumbers filename="Typescript" showLineNumbers filename="Typescript" showLineNumbers filename="Typescript"
-import { SUPPORTED_CHAINS } from @avail-project/nexus/core;
+import { SUPPORTED_CHAINS } from @avail-project/nexus;
 
 // Mainnet Chain IDs
 SUPPORTED_CHAINS.ETHEREUM;     // 1
@@ -168,7 +168,7 @@ SUPPORTED_CHAINS.SCROLL;       // 534351
 ### Initialization
 
 ```typescript showLineNumbers filename="Typescript"
-import type { NexusNetwork } from '@avail-project/nexus/core';
+import type { NexusNetwork } from '@avail-project/nexus';
 
 // Mainnet (default)
 const sdk = new NexusSDK();
@@ -183,7 +183,7 @@ await sdk.initialize(window.ethereum); // Returns: Promise<void>
 ### Unified Balance(s)
 
 ```typescript showLineNumbers filename="Typescript"
-import type { UserAsset, TokenBalance } from '@avail-project/nexus/core';
+import type { UserAsset, TokenBalance } from '@avail-project/nexus';
 
 // Get all balances across chains
 const balances: UserAsset[] = await sdk.getUnifiedBalances();
@@ -196,7 +196,7 @@ const usdcBalance: UserAsset | undefined = await sdk.getUnifiedBalance('USDC');
 ### Bridge Operations
 
 ```typescript showLineNumbers filename="Typescript"
-import type { BridgeParams, BridgeResult, SimulationResult } from '@avail-project/nexus/core';
+import type { BridgeParams, BridgeResult, SimulationResult } from '@avail-project/nexus';
 
 // Bridge tokens between chains
 const result: BridgeResult = await sdk.bridge({
@@ -216,7 +216,7 @@ const simulation: SimulationResult = await sdk.simulateBridge({
 ### Transfer Operations
 
 ```typescript showLineNumbers filename="Typescript"
-import type { TransferParams, TransferResult } from '@avail-project/nexus/core';
+import type { TransferParams, TransferResult } from '@avail-project/nexus';
 
 // Smart transfer with automatic optimization
 const result: TransferResult = await sdk.transfer({
@@ -255,7 +255,7 @@ import type {
   BridgeAndExecuteParams,
   BridgeAndExecuteResult,
   BridgeAndExecuteSimulationResult,
-} from '@avail-project/nexus/core';
+} from '@avail-project/nexus';
 
 // Execute contract functions with dynamic parameter builder - Compound V3 Supply
 const result: ExecuteResult = await sdk.execute({
@@ -357,7 +357,7 @@ console.log('Bridge receive amount:', simulation.metadata?.bridgeReceiveAmount);
 ### Allowance Management
 
 ```typescript showLineNumbers filename="Typescript"
-import type { AllowanceResponse } from '@avail-project/nexus/core';
+import type { AllowanceResponse } from '@avail-project/nexus';
 
 // Check allowances
 const allowances: AllowanceResponse[] = await sdk.getAllowance(137, ['USDC', 'USDT']);
@@ -372,7 +372,7 @@ await sdk.revokeAllowance(137, ['USDC']);
 ### Intent Management
 
 ```typescript showLineNumbers filename="Typescript"
-import type { RequestForFunds } from '@avail-project/nexus/core';
+import type { RequestForFunds } from '@avail-project/nexus';
 
 // Get user's transaction intents
 const intents: RequestForFunds[] = await sdk.getMyIntents(1);
@@ -383,7 +383,7 @@ const intents: RequestForFunds[] = await sdk.getMyIntents(1);
 All utility functions are available under `sdk.utils`:
 
 ```typescript showLineNumbers filename="Typescript"
-import type { ChainMetadata, TokenMetadata, SUPPORTED_TOKENS } from '@avail-project/nexus/core';
+import type { ChainMetadata, TokenMetadata, SUPPORTED_TOKENS } from '@avail-project/nexus';
 
 // Address utilities
 const isValid: boolean = sdk.utils.isValidAddress('0x...');
@@ -419,7 +419,7 @@ const decimalChainId: number = sdk.utils.hexToChainId('0x89');
 ### Event Handling
 
 ```typescript showLineNumbers filename="Typescript"
-import type { OnIntentHook, OnAllowanceHook, EventListener } from '@avail-project/nexus/core';
+import type { OnIntentHook, OnAllowanceHook, EventListener } from '@avail-project/nexus';
 
 // Intent approval flows
 sdk.setOnIntentHook(({ intent, allow, deny, refresh }: Parameters<OnIntentHook>[0]) => {
@@ -460,7 +460,7 @@ sdk.onChainChanged((chainId) => console.log('Chain:', chainId));
 ### Progress Events for All Operations
 
 ```typescript showLineNumbers filename="Typescript"
-import { NEXUS_EVENTS, ProgressStep } from '@avail-project/nexus/core';
+import { NEXUS_EVENTS, ProgressStep } from '@avail-project/nexus';
 
 // Bridge & Execute Progress
 const unsubscribeBridgeExecuteExpected = sdk.nexusEvents.on(
@@ -536,7 +536,7 @@ This provides consistent progress tracking whether using optimized direct operat
 ### Provider Methods
 
 ```typescript showLineNumbers filename="Typescript"
-import type { EthereumProvider, RequestArguments } from '@avail-project/nexus/core';
+import type { EthereumProvider, RequestArguments } from '@avail-project/nexus';
 
 // Get enhanced provider
 const provider: EthereumProvider = sdk.getEVMProviderWithCA();
@@ -556,7 +556,7 @@ await sdk.deinit();
 ### Basic Bridge with Result Handling
 
 ```typescript showLineNumbers filename="Typescript"
-import { NexusSDK, type BridgeResult } from '@avail-project/nexus/core';
+import { NexusSDK, type BridgeResult } from '@avail-project/nexus';
 
 const sdk = new NexusSDK();
 await sdk.initialize(window.ethereum);
@@ -584,7 +584,7 @@ try {
 ### Execute with Receipt Confirmation
 
 ```typescript showLineNumbers filename="Typescript"
-import type { ExecuteResult } from '@avail-project/nexus/core';
+import type { ExecuteResult } from '@avail-project/nexus';
 
 // MakerDAO DSR (Dai Savings Rate) Deposit
 const result: ExecuteResult = await sdk.execute({
@@ -632,7 +632,7 @@ console.log('Confirmations:', result.confirmations);
 ### Bridge and Execute with Error Handling
 
 ```typescript showLineNumbers filename="Typescript"
-import type { BridgeAndExecuteResult } from '@avail-project/nexus/core';
+import type { BridgeAndExecuteResult } from '@avail-project/nexus';
 
 try {
   const result: BridgeAndExecuteResult = await sdk.bridgeAndExecute({
@@ -692,7 +692,7 @@ try {
 ### Complete Portfolio Management
 
 ```typescript showLineNumbers filename="Typescript"
-import type { UserAsset, ChainMetadata } from '@avail-project/nexus/core';
+import type { UserAsset, ChainMetadata } from '@avail-project/nexus';
 
 // Get complete balance overview
 const balances: UserAsset[] = await sdk.getUnifiedBalances();
@@ -713,7 +713,7 @@ for (const asset of balances) {
 ## Error Handling
 
 ```typescript showLineNumbers filename="Typescript"
-import type { BridgeResult } from '@avail-project/nexus/core';
+import type { BridgeResult } from '@avail-project/nexus';
 
 try {
   const result: BridgeResult = await sdk.bridge({ token: 'USDC', amount: 100, chainId: 137 });

--- a/app/nexus/avail-nexus-sdk/examples/nexus-widgets/bridge-and-execute/page.mdx
+++ b/app/nexus/avail-nexus-sdk/examples/nexus-widgets/bridge-and-execute/page.mdx
@@ -105,7 +105,7 @@ The library then:
 ### Pre-filled Bridge & Execute
 
 ```tsx showLineNumbers filename="App.tsx"
-import { NexusProvider  BridgeAndExecuteButton, TOKEN_METADATA, TOKEN_CONTRACT_ADDRESSES } from '@avail-project/nexus/ui';
+import { NexusProvider  BridgeAndExecuteButton, TOKEN_METADATA, TOKEN_CONTRACT_ADDRESSES } from '@avail-project/nexus-widgets';
 import { parseUnits } from 'viem';
 
 function App() {

--- a/app/nexus/avail-nexus-sdk/examples/nexus-widgets/bridge-tokens/page.mdx
+++ b/app/nexus/avail-nexus-sdk/examples/nexus-widgets/bridge-tokens/page.mdx
@@ -56,7 +56,7 @@ Here are examples of how to use the `BridgeButton` widget:
 ### Basic Bridge Button
 
 ```tsx showLineNumbers filename="App.tsx"
-import {NexusProvider, BridgeButton } from '@avail-project/nexus/ui';
+import {NexusProvider, BridgeButton } from '@avail-project/nexus-widgets';
 
 function App() {
   return (
@@ -74,7 +74,7 @@ function App() {
 ### Pre-filled Bridge Button
 
 ```tsx showLineNumbers filename="App.tsx"
-import { NexusProvider, BridgeButton } from '@avail-project/nexus/ui';
+import { NexusProvider, BridgeButton } from '@avail-project/nexus-widgets';
 
 function App() {
   return (

--- a/app/nexus/avail-nexus-sdk/examples/nexus-widgets/transfer/page.mdx
+++ b/app/nexus/avail-nexus-sdk/examples/nexus-widgets/transfer/page.mdx
@@ -39,7 +39,7 @@ Here are examples of how to use the `TransferButton` widget:
 ### Basic Transfer Button
 
 ```tsx showLineNumbers filename="App.tsx"
-import { NexusProvider, TransferButton } from '@avail-project/nexus/ui';
+import { NexusProvider, TransferButton } from '@avail-project/nexus-widgets';
 
 function App() {
   return (
@@ -57,7 +57,7 @@ function App() {
 ### Pre-filled Transfer Button
 
 ```tsx showLineNumbers filename="App.tsx"
-import { NexusProvider, TransferButton } from '@avail-project/nexus/ui';
+import { NexusProvider, TransferButton } from '@avail-project/nexus-widgets';
 
 function App() {
   return (

--- a/app/nexus/avail-nexus-sdk/overview/page.mdx
+++ b/app/nexus/avail-nexus-sdk/overview/page.mdx
@@ -130,7 +130,7 @@ You still need to wrap your app with the `NexusProvider` before proceeding with 
 </Callout>
 
 ```tsx showLineNumbers filename="App.tsx"
-import { useNexus } from '@avail-project/nexus/ui';
+import { useNexus } from '@avail-project/nexus-widgets';
 
 function MyComponent() {
   const { initializeSdk, sdk, isSdkInitialized } = useNexus();


### PR DESCRIPTION
## Fixing wrong imports in Nexus Docs

- Nexus SDK imports changed from `@avail-project/nexus/core` to `@avail-project/nexus` & from `@avail-project/nexus/ui` to `@avail-project/nexus-widgets`

## Checklist

- [x] run `pnpm build` locally to make sure build compiles without errors.